### PR TITLE
fix execution of plugin in Gazebo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,36 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 project(storm_gazebo_magnet)
 
-find_package(catkin REQUIRED COMPONENTS 
-  roscpp 
-  geometry_msgs 
-  )
+  
+find_package(catkin REQUIRED COMPONENTS
+  geometry_msgs
+  roscpp
+  gazebo_plugins
+)  
+  
 find_package(gazebo REQUIRED)
-include_directories(include ${GAZEBO_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
-link_directories(${GAZEBO_LIBRARY_DIRS})
 
+include_directories(
+  include
+  ${Boost_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+  ${GAZEBO_INCLUDE_DIRS}
+  ${GAZEBO_PLUGINS_INCLUDE_DIRS}
+)
 find_package(gazebo REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
 # set (CMAKE_CXX_FLAGS "-std=c++11")
 add_definitions(-std=c++11)
 list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS} -O2")
 
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES
+  CATKIN_DEPENDS geometry_msgs roscpp gazebo_plugins
+  DEPENDS gazebo
+)
 
-add_library(storm_gazebo_dipole_magnet SHARED src/dipole_magnet.cc)
+add_library(storm_gazebo_dipole_magnet src/dipole_magnet.cc)
+add_dependencies(storm_gazebo_dipole_magnet ${catkin_EXPORTED_TARGETS})
 target_link_libraries(storm_gazebo_dipole_magnet ${GAZEBO_LIBRARIES} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,15 +19,14 @@ include_directories(
 )
 find_package(gazebo REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
-# set (CMAKE_CXX_FLAGS "-std=c++11")
 add_definitions(-std=c++11)
+
 list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS} -O2")
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES
   CATKIN_DEPENDS geometry_msgs roscpp gazebo_plugins
-  DEPENDS gazebo
 )
 
 add_library(storm_gazebo_dipole_magnet src/dipole_magnet.cc)

--- a/include/storm_gazebo_ros_magnet/dipole_magnet.h
+++ b/include/storm_gazebo_ros_magnet/dipole_magnet.h
@@ -29,7 +29,7 @@
 
 #include <memory>
 
-#include "storm_gazebo_ros_magnet/dipole_magnet_container.h"
+#include <storm_gazebo_ros_magnet/dipole_magnet_container.h>
 
 namespace gazebo {
 

--- a/launch/example.launch
+++ b/launch/example.launch
@@ -1,0 +1,8 @@
+<launch>
+    
+    <include file="$(find gazebo_ros)/launch/empty_world.launch">
+           <arg name="paused" value="false" />
+           <arg name="world_name" value="$(find storm_gazebo_magnet)/worlds/dipole_magnet.world" />
+           
+    </include>    
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,9 @@
   <run_depend>roscpp</run_depend>
   <run_depend>gazebo</run_depend>
   <run_depend>gazebo_msgs</run_depend>
-
+  <build_depend>geometry_msgs</build_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <build_depend>gazebo_plugins</build_depend>
+  <run_depend>gazebo_plugins</run_depend>
 </package>
 

--- a/package.xml
+++ b/package.xml
@@ -9,7 +9,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>gazebo</build_depend>
   <build_depend>gazebo_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <run_depend>message_runtime</run_depend> 

--- a/src/dipole_magnet.cc
+++ b/src/dipole_magnet.cc
@@ -28,7 +28,7 @@
 #include <vector>
 #include <cstdint>
 
-#include "storm_gazebo_ros_magnet/dipole_magnet.h"
+#include <storm_gazebo_ros_magnet/dipole_magnet.h>
 
 namespace gazebo {
 
@@ -185,6 +185,8 @@ void DipoleMagnet::OnUpdate(const common::UpdateInfo & /*_info*/) {
 
   if (!this->mag->calculate)
     return;
+
+
 
   DipoleMagnetContainer& dp = DipoleMagnetContainer::Get();
 


### PR DESCRIPTION
had some issues with executing the plugin, I first cloned the electromagnet branch of larics, after I got the plugin running I decided to go back to your master cause that feature seems to be not finished yet completely.  Maybe I do some more changes later, but maybe you want those here - Back to the issue: The plugin was completely not executed by Gazebo on my system - no error no warning, just nothing. After I copied stuff from my plugin I once wrote, it started working. I do not know what exactly did the trick but you mainly missed the catkin_package command in the CMakeLists.txt - with that in place you would also have noticed that you missed the geometry_msgs dependency in the package.xml which I also added. I mainly copied that stuff from gazebo_plugins when I did my plugin.